### PR TITLE
修复: 购物车商品单项-单项金额与数量不一致

### DIFF
--- a/src/main/java/tmall/controller/front/OrderFrontController.java
+++ b/src/main/java/tmall/controller/front/OrderFrontController.java
@@ -46,7 +46,7 @@ public class OrderFrontController extends FrontBaseController {
         }
 
         cartItem.setNumber(num);
-        cartItem.setSum(product.getNowPrice().subtract(new BigDecimal(num)));
+        cartItem.setSum(product.getNowPrice().multiply(new BigDecimal(num)));
 
         if (isInDB) {
             cartItemService.update(cartItem);
@@ -76,7 +76,7 @@ public class OrderFrontController extends FrontBaseController {
         if (cartItemFromDB.getProduct().getStock() >= num) {
             cartItemFromDB.setNumber(num);
             cartItemFromDB.setSum(cartItemFromDB.getProduct()
-                    .getNowPrice().subtract(new BigDecimal(num)));
+                    .getNowPrice().multiply(new BigDecimal(num)));
             cartItemService.update(cartItemFromDB);
             msg = "success";
         }


### PR DESCRIPTION
修复: 购物车商品单项-单项金额与数量不一致
原因: 大数字方法调用错误